### PR TITLE
Add ESC key support to close HomeBound window

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -327,6 +327,9 @@ local closeBtn = CreateFrame("Button", nil, frame, "UIPanelCloseButton")
 closeBtn:SetPoint("TOPRIGHT", -2, -2)
 closeBtn:SetSize(28, 28)
 
+-- Register frame to close on ESC key
+tinsert(UISpecialFrames, "HB_MainFrame")
+
 local toggleBtn = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
 toggleBtn:SetSize(140, 24)
 toggleBtn:SetPoint("TOPLEFT", 10, -60)


### PR DESCRIPTION
## Summary
  Adds ESC key functionality to close the HomeBound window, improving user experience and consistency with standard
  WoW UI behavior.

  ## Changes
  - Registered `HB_MainFrame` with `UISpecialFrames` table
  - Frame now closes when ESC key is pressed (when it's the active top-level window)

  ## Implementation
  Added a single line after the close button creation in `main.lua`:
  ```
  tinsert(UISpecialFrames, "HB_MainFrame")
```

  This follows the same pattern used by other popular addons and Blizzard's own UI frames.

## Testing
  - Open HomeBound window (`/hb` or `/homebound`)
  - Press ESC key
  - Window closes as expected
  - No conflicts with other ESC-closeable frames